### PR TITLE
Remove unnecessary comments

### DIFF
--- a/JS-Interpreters/ecmaref6/bindings/node-bindings.esl
+++ b/JS-Interpreters/ecmaref6/bindings/node-bindings.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -28,27 +28,17 @@ import "./node_shelljs.esl";
 function push_globals() {
   let saved_globals = {
     global: |global|,
-    /* Intrinsics: |Intrinsics|, */
     ctxStack : |ctxStack|,
-    /* __CUR__SYMB__ : |__CUR__SYMB__|, */
-    /* GlobalSymbolRegistry : |GlobalSymbolRegistry|, */
-    /* ElementTable : |ElementTable|, */
     ScriptJobQueue : |ScriptJobQueue|,
     PromiseJobQueue : |PromiseJobQueue|,
     __dirname : |__dirname|,
     __filename : |__filename|
-    /* realm : |realm| */
   };
   |global| := 'undefined;
   |realm|["globalThis"] := 'undefined;
-  /* |Intrinsics| := {}; */
   |ctxStack| := stack_make();
-  /* |__CUR__SYMB__| := 0; */
-  /* |GlobalSymbolRegistry| := {}; */
-  /* |ElementTable| := {}; */
   |ScriptJobQueue| := [];
   |PromiseJobQueue| := [];
-  /* |realm| := {}; */
   stack_push(|globals_stack|,  saved_globals);
   return;
 }
@@ -57,16 +47,11 @@ function pop_globals() {
   let saved_globals = stack_pop(|globals_stack|);
   |global| := saved_globals.global;
   |realm|["globalThis"] := saved_globals.global;
-  /* |Intrinsics| := saved_globals.Intrinsics; */
   |ctxStack| := saved_globals.ctxStack;
-  /* |__CUR__SYMB__| := saved_globals.__CUR__SYMB__; */
-  /* |GlobalSymbolRegistry| := saved_globals.GlobalSymbolRegistry; */
-  /* |ElementTable| := saved_globals.ElementTable; */
   |ScriptJobQueue| := saved_globals.ScriptJobQueue;
   |PromiseJobQueue| := saved_globals.PromiseJobQueue;
   |__dirname| := saved_globals.__dirname;
   |__filename| := saved_globals.__filename;
-  /* |realm| := saved_globals.realm; */
   return;
 }
 

--- a/JS-Interpreters/ecmaref6/section 15/section_15.10.esl
+++ b/JS-Interpreters/ecmaref6/section 15/section_15.10.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -234,15 +234,6 @@ function newRegExp(strict, pattern, flags) {
 
 
 function getRegExpPrototypeExec(strict) {
-  /* refObj := newPropertyReference(|global|, "RegExp", strict);
-  RegExpObject := GetValue(refObj);
-
-  refRegExpProto := newPropertyReference(RegExpObject, "prototype", strict);
-  regexpObjectProto := GetValue(refRegExpProto);
-
-  refExec := newPropertyReference(regexpObjectProto, "exec", strict);
-  regExpObjectExec := GetValue(refExec); */
-
   return |Intrinsics|["RegExpPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 18/section_18.esl
+++ b/JS-Interpreters/ecmaref6/section 18/section_18.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -336,18 +336,6 @@ function parseAsProgram(progStr, strict) {
   progObj := {prog}();
   progObj.codeType := "eval";
   return progObj;
-}
-
-/* FIXME: Remove this? */
-function optimizeInitGlobalObject(strict) {
-  loc_global := null;
-  if (typeof strict == "bool" &&& strict)
-    loc_global := extern loadInitialHeap("globalHeap_strict.json");
-  else
-    loc_global := extern loadInitialHeap("globalHeap.json");
-
-  |global| := loc_global;
-  return loc_global;
 }
 
 function removeLeadingWhitespace(str) {

--- a/JS-Interpreters/ecmaref6/section 19/section_19.2.esl
+++ b/JS-Interpreters/ecmaref6/section 19/section_19.2.esl
@@ -412,11 +412,6 @@ function HasInstanceBind(F, V) {
 /* Auxiliary functions */
 
 function getFunctionPrototype(strict) {
-  /* refObj := newPropertyReference(|global|, "Function", strict);
-  FunctionObject := GetValue(refObj);
-
-  refObjProto := newPropertyReference(FunctionObject, "prototype", strict);
-  functionObjectProto := GetValue(refObjProto); */
   return |Intrinsics|["FunctionPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 19/section_19.3.esl
+++ b/JS-Interpreters/ecmaref6/section 19/section_19.3.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -172,10 +172,5 @@ function thisBooleanValue(value) {
 }
 
 function getBooleanPrototype(strict) {
-  /* refError := newPropertyReference(|global|, "Boolean", strict);
-  BooleanObject := GetValue(refError);
-  
-  refBooleanProto := newPropertyReference(BooleanObject, "prototype", strict);
-  booleanObjectProto := GetValue(refBooleanProto); */
   return |Intrinsics|["BooleanPrototype"];
 }

--- a/JS-Interpreters/ecmaref6/section 20/section_20.1.esl
+++ b/JS-Interpreters/ecmaref6/section 20/section_20.1.esl
@@ -98,11 +98,6 @@ function initNumberPrototype(global, objectPrototype, strict) {
 
 
 function getNumberPrototype(strict) {
-  /* refNumber := newPropertyReference(|global|, "Number", strict);
-  NumberObject := GetValue(refNumber);
-  refNumberProto := newPropertyReference(NumberObject, "prototype", strict);
-  objectNumberProto := GetValue(refNumberProto); */
-
   return |Intrinsics|["NumberPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 20/section_20.3.esl
+++ b/JS-Interpreters/ecmaref6/section 20/section_20.3.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -2261,12 +2261,6 @@ function fillDatePrototype(datePrototypeObject, dateConstructor, globalObject, s
 
 
 function getDatePrototype(strict) {
-  /* refDate := newPropertyReference(|global|, "Date", strict);
-  DateObject := GetValue(refDate);
-
-  refDateProto := newPropertyReference(DateObject, "prototype", strict);
-  objectDateProto := GetValue(refDateProto); */
-
   return |Intrinsics|["DatePrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 21/section_21.1.esl
+++ b/JS-Interpreters/ecmaref6/section 21/section_21.1.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -58,10 +58,6 @@ function StringConstructor(global, this, NewTarget, strict, args) {
 }
 
 function getStringPrototype() {
-  /* refString := newPropertyReference(|global|, "String", strict);
-  StringObject := GetValue(refString);
-  refStringProto := newPropertyReference(StringObject, "prototype", strict);
-  StringProto := GetValue(refStringProto); */
   return |Intrinsics|["StringPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 21/section_21.2.esl
+++ b/JS-Interpreters/ecmaref6/section 21/section_21.2.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -350,12 +350,6 @@ function RegExpAlloc(newTarget) {
 
 /* AUXILIARY FUNCTIONS */
 function getRegExpPrototype(strict) {
-  /* refRegExp := newPropertyReference(|global|, "RegExp", strict);
-  RegExpObject := GetValue(refRegExp);
-
-  refRegExpProto := newPropertyReference(RegExpObject, "prototype", strict);
-  objectRegExpProto := GetValue(refRegExpProto); */
-
   return |Intrinsics|["RegExpPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 22/section_22.1.esl
+++ b/JS-Interpreters/ecmaref6/section 22/section_22.1.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -480,11 +480,6 @@ function initArrayPrototype(global, objectPrototype, strict) {
 
 function getArrayPrototype(strict) {
   return |Intrinsics|["ArrayPrototype"];
-  /*refArray := newPropertyReference(|global|, "Array", strict);
-  ArrayObject := GetValue(refArray);
-  refArrayProto := newPropertyReference(ArrayObject, "prototype", strict);
-  objectArrayProto := GetValue(refArrayProto);
-  return objectArrayProto */
 }
 
 

--- a/JS-Interpreters/ecmaref6/section 23/section_23.1.esl
+++ b/JS-Interpreters/ecmaref6/section 23/section_23.1.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -134,10 +134,6 @@ function MapSpeciesGetter(global, this, NewTarget, strict, args) {
 }
 
 function getMapPrototype(strict) {
-  /* refMap := newPropertyReference(|global|, "Map", strict);
-  MapObject := GetValue(refMap);
-  refMapProto := newPropertyReference(MapObject, "prototype", strict);
-  objectMapProto := GetValue(refMapProto); */
   return |Intrinsics|["MapPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 23/section_23.2.esl
+++ b/JS-Interpreters/ecmaref6/section 23/section_23.2.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -109,11 +109,6 @@ function initSetPrototype(global, objectPrototype, strict) {
 }
 
 function getSetPrototype (strict) {
-
-  /* refSet := newPropertyReference(|global|, "Set", strict);
-  SetObject := GetValue(refSet);
-  refSetProto := newPropertyReference(SetObject, "prototype", strict);
-  objectSetProto := GetValue(refSetProto); */
   return |Intrinsics|["SetPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 24/section_24.1.esl
+++ b/JS-Interpreters/ecmaref6/section 24/section_24.1.esl
@@ -1,15 +1,15 @@
 /* Copyright (C) 2022-2025 formalsec programmers
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -136,10 +136,6 @@ function ArrayBufferConstructor(global, this, NewTarget, strict, args) {
 }
 
 function getArrayBufferPrototype(strict) {
-  /* refArrayBuffer := newPropertyReference(|global|, "ArrayBuffer", strict);
-  ArrayBufferObject := GetValue(refArrayBuffer);
-  refArrayBufferProto := newPropertyReference(ArrayBufferObject, "prototype", strict);
-  objectArrayBufferProto := GetValue(refArrayBufferProto); */
   return |Intrinsics|["ArrayBufferPrototype"];
 }
 

--- a/JS-Interpreters/ecmaref6/section 9/section_9.2.esl
+++ b/JS-Interpreters/ecmaref6/section 9/section_9.2.esl
@@ -150,7 +150,6 @@ function OrdinaryCallBindThis (F, calleeContext, thisArgument) {
     if (thisArgument == 'undefined ||| thisArgument == 'null) {
       /* a. Let thisValue be calleeRealm.[[globalThis]].  */
       thisValue := calleeRealm.globalThis;
-      /*thisValue := |global|*/
     /* b. Else,  */
     } else {
         /* c. Let thisValue be ToObject(thisArgument).  */


### PR DESCRIPTION
Remove unnecessary comments.

Currently the most used (by code references) global variables are `|Intrinsics|`, `|global|`, and `|realm|`. I think only having these three is acceptable. Although we could probably reduce this even further and only use `|realm|` since it has pointers to the same objects `|Intrinsics|` and `|global|` point to. But I think this is good enough to close #219.

Then we also have a couple implementation global variables to maintain the state of the interpreter, but these we cannot get rid of. Some of them are:
- `|ElementTable|`
- `|ctxStack|` 
- `|ScriptJobQueue|`
- `|PromiseJobQueue|`
- ...